### PR TITLE
build super front modules

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -39,8 +39,11 @@ if [ -e "$envdir/GULPFILE" ]; then
     GULPFILE=$(cat $envdir/GULPFILE)
 fi
 
-cd $build
+echo "-----> installing super-front node modules ..."
+cd $build/app/assets/super-front
+npm install
 
+cd $build
 echo "-----> using gulpfile ${GULPFILE:-gulpfile.js} ..."
 gulp --gulpfile ${GULPFILE:-gulpfile.js} assets:copy 2>&1
 


### PR DESCRIPTION
runs npm install in the super-front dir so the node modules are available for asset compilation