### PR TITLE
create the apikeys.properties file for stormpath

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -44,5 +44,10 @@ cd $build
 echo "-----> using gulpfile ${GULPFILE:-gulpfile.js} ..."
 gulp --gulpfile ${GULPFILE:-gulpfile.js} assets:copy 2>&1
 
+echo "-----> creating stormpath properties file... working directory is: "
+echo `pwd`
+echo "apiKey.id=$STORMPATH_API_KEY_ID" > apikey.properties
+echo "apiKey.secret=$STORMPATH_API_KEY_SECRET" >> apikey.properties
+
 mkdir -p $build/bin
 cp `which goose` $build/bin


### PR DESCRIPTION
* modified buildpack to generate the apikey.properties file now required by the latest (and last version of github.com/jarias/stormpath-sdk-go)  to configure the credentials
* we need to do this before merging branch=[upgrade-to-go1.8] into development
* until upgrade-to-go1.8 is merged, this new apokey.properties file will not affect anything so there is no need to worry about it existing before upgrade-to-go1.8 is merged