### PR TITLE
Remove node_modules after build.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -49,3 +49,7 @@ gulp --gulpfile ${GULPFILE:-gulpfile.js} assets:copy 2>&1
 
 mkdir -p $build/bin
 cp `which goose` $build/bin
+
+echo "-----> remove super-front node_modules ...."
+rm -rf $build/app/assets/super-front/node_modules
+rm -rf $build/node_modules


### PR DESCRIPTION
Removing node_modules folders after build in order to reduce slug size.

Tested on super-fork.