### PR TITLE
Remove gulp command from build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -39,7 +39,6 @@ cd $build/app/assets/super-front
 npm install
 
 cd $build
-echo $PWD
 make copy_assets 2>&1
 
 mkdir -p $build/bin

--- a/bin/compile
+++ b/bin/compile
@@ -44,8 +44,8 @@ cd $build/app/assets/super-front
 npm install
 
 cd $build
-#echo "-----> using gulpfile ${GULPFILE:-gulpfile.js} ..."
-#gulp --gulpfile ${GULPFILE:-gulpfile.js} assets:copy 2>&1
+echo "-----> using gulpfile ${GULPFILE:-gulpfile.js} ..."
+gulp --gulpfile ${GULPFILE:-gulpfile.js} assets:copy 2>&1
 
 mkdir -p $build/bin
 cp `which goose` $build/bin

--- a/bin/compile
+++ b/bin/compile
@@ -39,6 +39,7 @@ cd $build/app/assets/super-front
 npm install
 
 cd $build
+echo $PWD
 make copy_assets 2>&1
 
 mkdir -p $build/bin

--- a/bin/compile
+++ b/bin/compile
@@ -34,18 +34,12 @@ if [ -d "$envdir" ]; then
     done
 fi
 
-if [ -e "$envdir/GULPFILE" ]; then
-    echo "Alternate gulpfile located"
-    GULPFILE=$(cat $envdir/GULPFILE)
-fi
-
 echo "-----> installing super-front node modules ..."
 cd $build/app/assets/super-front
 npm install
 
 cd $build
-#echo "-----> using gulpfile ${GULPFILE:-gulpfile.js} ..."
-make copy_app_assets 2>&1
+make copy_assets 2>&1
 
 mkdir -p $build/bin
 cp `which goose` $build/bin

--- a/bin/compile
+++ b/bin/compile
@@ -44,8 +44,8 @@ cd $build/app/assets/super-front
 npm install
 
 cd $build
-echo "-----> using gulpfile ${GULPFILE:-gulpfile.js} ..."
-gulp --gulpfile ${GULPFILE:-gulpfile.js} assets:copy 2>&1
+#echo "-----> using gulpfile ${GULPFILE:-gulpfile.js} ..."
+make copy_app_assets 2>&1
 
 mkdir -p $build/bin
 cp `which goose` $build/bin

--- a/bin/compile
+++ b/bin/compile
@@ -44,8 +44,8 @@ cd $build/app/assets/super-front
 npm install
 
 cd $build
-echo "-----> using gulpfile ${GULPFILE:-gulpfile.js} ..."
-gulp --gulpfile ${GULPFILE:-gulpfile.js} assets:copy 2>&1
+#echo "-----> using gulpfile ${GULPFILE:-gulpfile.js} ..."
+#gulp --gulpfile ${GULPFILE:-gulpfile.js} assets:copy 2>&1
 
 mkdir -p $build/bin
 cp `which goose` $build/bin


### PR DESCRIPTION
Since we are moving from gulp build tool to MAKE we need to make changes on build script for heroku in order to make our build to work.