### PR TITLE
Add installation of node in buildpack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -26,6 +26,7 @@ virtualenv() {
 }
 
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
 nvm install 18.18.0
 
 echo "-----> precompiling assets ..."

--- a/bin/compile
+++ b/bin/compile
@@ -25,8 +25,7 @@ virtualenv() {
     python "$buildpack/thirdparty/virtualenv-1.11.6/virtualenv.py" "$@"
 }
 
-curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
-sudo apt-get install -y nodejs
+curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash - && sudo apt-get install -y nodejs
 
 echo "-----> precompiling assets ..."
 

--- a/bin/compile
+++ b/bin/compile
@@ -26,7 +26,7 @@ virtualenv() {
 }
 
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
-export NVM_DIR="$HOME/.nvm"
+[[ -s $HOME/.nvm/nvm.sh ]] && . $HOME/.nvm/nvm.sh
 nvm install 18.18.0
 
 echo "-----> precompiling assets ..."

--- a/bin/compile
+++ b/bin/compile
@@ -25,7 +25,8 @@ virtualenv() {
     python "$buildpack/thirdparty/virtualenv-1.11.6/virtualenv.py" "$@"
 }
 
-curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash - && sudo apt-get install -y nodejs
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+nvm install 18.18.0
 
 echo "-----> precompiling assets ..."
 

--- a/bin/compile
+++ b/bin/compile
@@ -25,7 +25,7 @@ virtualenv() {
     python "$buildpack/thirdparty/virtualenv-1.11.6/virtualenv.py" "$@"
 }
 
-curl -fsSL https://deb.nodesource.com/setup_18.18.0 | bash -
+curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
 apt-get install -y nodejs
 
 echo "-----> precompiling assets ..."

--- a/bin/compile
+++ b/bin/compile
@@ -26,7 +26,7 @@ virtualenv() {
 }
 
 curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
-apt-get install -y nodejs
+sudo apt-get install -y nodejs
 
 echo "-----> precompiling assets ..."
 

--- a/bin/compile
+++ b/bin/compile
@@ -25,6 +25,9 @@ virtualenv() {
     python "$buildpack/thirdparty/virtualenv-1.11.6/virtualenv.py" "$@"
 }
 
+curl -fsSL https://deb.nodesource.com/setup_18.18.0 | bash -
+apt-get install -y nodejs
+
 echo "-----> precompiling assets ..."
 
 if [ -d "$envdir" ]; then


### PR DESCRIPTION
After removing node from our backend we will also remove package.json.
Since heroku require package.json in root of project in order to install his default buildpack and after our change this won't be possible, we need to add node installation in our buildpack.